### PR TITLE
JavaScriptでカレンダーのプログラムを作成する

### DIFF
--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,0 +1,39 @@
+import minimist from "minimist";
+
+const today = new Date();
+const year = today.getFullYear();
+const month = today.getMonth() + 1;
+
+const argv = minimist(process.argv.slice(2), {
+  alias: {
+    y: "year",
+    m: "month",
+  },
+  default: {
+    year,
+    month,
+  },
+});
+
+const year_option = argv.year;
+const month_option = argv.month;
+
+const start_day = new Date(year_option, month_option - 1, 1);
+const end_day = new Date(year_option, month_option, 0);
+
+console.log(`      ${month_option}月 ${year_option}        `);
+console.log("日 月 火 水 木 金 土");
+
+let start_day_space = "   ".repeat(start_day.getDay());
+
+for (let day = 1; day <= end_day.getDate(); day++) {
+  start_day_space += day.toString().padStart(2);
+  if (start_day.getDay() === 6 || day === end_day.getDate()) {
+    start_day_space += "\n";
+  } else {
+    start_day_space += " ";
+  }
+
+  start_day.setDate(start_day.getDate() + 1);
+}
+console.log(start_day_space);

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "minimist": "^1.2.8"
+      },
       "devDependencies": {
         "eslint": "^8.43.0",
         "eslint-config-prettier": "^8.8.0",
@@ -778,6 +781,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {
@@ -1706,6 +1717,11 @@
       "requires": {
         "brace-expansion": "^1.1.7"
       }
+    },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "ms": {
       "version": "2.1.2",

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -8,5 +8,8 @@
     "eslint-config-prettier": "^8.8.0",
     "prettier": "^2.8.8"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "minimist": "^1.2.8"
+  }
 }

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "fix": "prettier --write . && eslint --fix .",
-    "lint": "prettier --check . && eslint ."
+    "lint": "prettier --check . && eslint .",
+    "format": "prettier --write '*.js'"
   },
   "devDependencies": {
     "eslint": "^8.43.0",

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "fix": "prettier --write . && eslint --fix .",
     "lint": "prettier --check . && eslint .",
-    "format": "prettier --write '*.js'"
+    "format": "eslint '*.js' --fix && prettier --write '*.js'"
   },
   "devDependencies": {
     "eslint": "^8.43.0",


### PR DESCRIPTION
今月のカレンダーを表示するプログラムを書く
- Node.jsで実行するコマンドラインのプログラムとして作る
- OS に入っている cal コマンドと同じ見た目にする(今日の日付の部分の色が反転してるところはやらなくてもいい)
- `-m` で月を、`-y` で年を指定できるようにする
- 指定しない場合は今月・今年を表示させる
- 1970年から2100年までは表示できる
- ESLint と Prettier の両方でチェックする